### PR TITLE
feat(web-upload): add browser upload session endpoints and tighten CO…

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"indicer/lib/util"
 	"indicer/pb/pbconnect"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -64,6 +65,11 @@ func Server(chonkSize int, dbpath string, key []byte) error {
 		server.NewConnectService(),
 	)
 	mux.Handle(path, handler)
+
+	// Unary web upload endpoints (browser-compatible alternative to client-streaming RPC).
+	mux.HandleFunc("/web/upload/start", server.HandleUploadStart)
+	mux.HandleFunc("/web/upload/chunk", server.HandleUploadChunk)
+	mux.HandleFunc("/web/upload/finalize", server.HandleUploadFinalize)
 
 	// Add a health check endpoint
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -178,32 +184,47 @@ func printSection(icon, title string, lines []string, c *color.Color) {
 	fmt.Println()
 }
 
+func isLocalhostOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
 func corsMiddleware(next http.Handler) http.Handler {
+	const allowMethods = "POST, OPTIONS"
+	const allowHeaders = "content-type,x-grpc-web,grpc-timeout,x-user-agent,connect-protocol-version,upload-id"
+	const exposeHeaders = "grpc-status,grpc-message,grpc-status-details-bin"
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Set CORS headers for web clients
+		isPreflight := r.Method == http.MethodOptions
+		isGRPCWeb := r.Header.Get("X-Grpc-Web") != ""
 		origin := r.Header.Get("Origin")
-		if origin != "" {
-			// Allow all origins - customize this for production to restrict to specific domains
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+		// Only attach CORS headers for browser-originated traffic, preflight, or grpc-web.
+		if isPreflight || isGRPCWeb || isLocalhostOrigin(origin) {
+			allowedOrigin := origin
+			if allowedOrigin == "" {
+				allowedOrigin = "*"
+			}
+			w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+			w.Header().Set("Access-Control-Allow-Methods", allowMethods)
+			w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
+			w.Header().Set("Access-Control-Expose-Headers", exposeHeaders)
+			w.Header().Add("Vary", "Origin")
+			w.Header().Add("Vary", "Access-Control-Request-Method")
+			w.Header().Add("Vary", "Access-Control-Request-Headers")
 		}
 
-		// Handle preflight requests
-		if r.Method == http.MethodOptions {
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers",
-				"Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, "+
-					"Connect-Accept-Encoding, Connect-Content-Encoding, "+
-					"Grpc-Timeout, X-Grpc-Web, X-User-Agent")
-			w.Header().Set("Access-Control-Max-Age", "7200")
+		if isPreflight {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-
-		// Expose headers for web clients
-		w.Header().Set("Access-Control-Expose-Headers",
-			"Connect-Protocol-Version, Connect-Content-Encoding, "+
-				"Grpc-Status, Grpc-Message, Grpc-Status-Details-Bin")
 
 		next.ServeHTTP(w, r)
 	})

--- a/lib/server/uploadweb.go
+++ b/lib/server/uploadweb.go
@@ -1,0 +1,225 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"indicer/lib/cnst"
+	"indicer/lib/service"
+	"indicer/lib/util"
+	"indicer/pb"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// uploadSession holds an in-progress web upload.
+type uploadSession struct {
+	file    *os.File
+	meta    *pb.StreamFileMeta
+	created time.Time
+}
+
+var uploadSessions sync.Map
+
+func init() {
+	const sessionTTL = 30 * time.Minute
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			now := time.Now()
+			uploadSessions.Range(func(key, value any) bool {
+				sess := value.(*uploadSession)
+				if now.Sub(sess.created) > sessionTTL {
+					sess.file.Close()
+					os.Remove(sess.file.Name())
+					uploadSessions.Delete(key)
+				}
+				return true
+			})
+		}
+	}()
+}
+
+type webBaseFile struct {
+	FilePath string           `json:"file_path"`
+	FileId   string           `json:"file_id"`
+	FileSize int64            `json:"file_size"`
+	ChunkMap map[string]int64 `json:"chunk_map"`
+}
+
+type webUploadRes struct {
+	Done    bool         `json:"done"`
+	Err     string       `json:"err,omitempty"`
+	EviFile *webBaseFile `json:"evi_file,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v) //nolint:errcheck
+}
+
+// HandleUploadStart creates an upload session for a browser client.
+//
+//	POST /web/upload/start
+//	Body JSON: {"file_path":"...","file_type":"...","file_hash":"..."}
+//	Response JSON: {"upload_id":"..."}
+func HandleUploadStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var meta pb.StreamFileMeta
+	if err := json.NewDecoder(r.Body).Decode(&meta); err != nil {
+		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if meta.FileHash == "" {
+		http.Error(w, cnst.ErrHashNotFound.Error(), http.StatusBadRequest)
+		return
+	}
+
+	fh, err := getFileHandle(cnst.DB)
+	if err != nil {
+		http.Error(w, "failed to create upload file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	sid, err := uuid.NewV7()
+	if err != nil {
+		fh.Close()
+		os.Remove(fh.Name())
+		http.Error(w, "failed to generate session id: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	uploadSessions.Store(sid.String(), &uploadSession{
+		file:    fh,
+		meta:    &meta,
+		created: time.Now(),
+	})
+
+	writeJSON(w, http.StatusOK, map[string]string{"upload_id": sid.String()})
+}
+
+// HandleUploadChunk appends a binary chunk to an active upload session.
+//
+//	POST /web/upload/chunk
+//	Header: Upload-Id: <upload_id>
+//	Body: raw binary chunk bytes
+//	Response JSON: {"ok":true}
+func HandleUploadChunk(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sid := r.Header.Get("Upload-Id")
+	if sid == "" {
+		http.Error(w, "missing Upload-Id header", http.StatusBadRequest)
+		return
+	}
+
+	val, ok := uploadSessions.Load(sid)
+	if !ok {
+		http.Error(w, "upload session not found or expired", http.StatusNotFound)
+		return
+	}
+	sess := val.(*uploadSession)
+
+	if _, err := io.Copy(sess.file, r.Body); err != nil {
+		http.Error(w, "failed to write chunk: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// HandleUploadFinalize closes the upload, stores and indexes the file, and returns the result.
+//
+//	POST /web/upload/finalize
+//	Body JSON: {"upload_id":"..."}
+//	Response JSON: webUploadRes
+func HandleUploadFinalize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		UploadID string `json:"upload_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.UploadID == "" {
+		http.Error(w, "missing upload_id", http.StatusBadRequest)
+		return
+	}
+
+	val, ok := uploadSessions.LoadAndDelete(body.UploadID)
+	if !ok {
+		http.Error(w, "upload session not found or already finalized", http.StatusNotFound)
+		return
+	}
+	sess := val.(*uploadSession)
+	fpath := sess.file.Name()
+
+	if err := sess.file.Close(); err != nil {
+		os.Remove(fpath)
+		http.Error(w, "error closing upload file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := service.StoreStreamedFile(fpath); err != nil {
+		os.Remove(fpath)
+		http.Error(w, "store failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	efile, err := service.AddEvidenceMetadata(sess.meta)
+	if err != nil {
+		os.Remove(fpath)
+		http.Error(w, "metadata failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fhash, err := base64.StdEncoding.DecodeString(sess.meta.FileHash)
+	if err != nil {
+		os.Remove(fpath)
+		http.Error(w, "hash decode failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	chunkMap, err := service.GetFileChunkMap(efile.Start, efile.Size, fhash)
+	if err != nil {
+		os.Remove(fpath)
+		http.Error(w, "chunk map failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := os.Remove(fpath); err != nil {
+		log.Printf("Warning: could not remove temp file %s: %v\n", fpath, err)
+	}
+
+	eid := util.AppendToBytesSlice(cnst.EviFileNamespace, fhash)
+	fileId := base64.StdEncoding.EncodeToString(eid)
+
+	writeJSON(w, http.StatusOK, webUploadRes{
+		Done: true,
+		EviFile: &webBaseFile{
+			FilePath: sess.meta.FilePath,
+			FileId:   fileId,
+			FileSize: efile.Size,
+			ChunkMap: chunkMap,
+		},
+	})
+}


### PR DESCRIPTION
> Protocol adaptation: introduced unary HTTP endpoints as a browser-compatible alternative to client-streaming RPC.
> Stateful chunked upload flow: three-phase start/chunk/finalize workflow with server-side session tracking.
> Defensive programming: request method checks, input validation, structured error responses, and cleanup on failure paths.
> Resource lifecycle management: temp-file handling plus TTL-based stale session eviction.
> Incremental integration: reused existing service-layer functions for storage, metadata, and chunk-map generation instead of duplicating logic.
> CORS hardening: conditional header application and cache-correct Vary headers for browser traffic.

Implemented:
1. Add /web/upload/start, /web/upload/chunk, and /web/upload/finalize endpoints
2. Implement upload session lifecycle with TTL cleanup
3. Reuse existing store/metadata/chunk-map service pipeline on finalize
4. Restrict CORS handling to preflight, grpc-web, and localhost-origin browser traffic